### PR TITLE
Integrate support for CFLAGS and LDFLAGS into the build process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub struct Config {
     path: PathBuf,
     cflags: OsString,
     cxxflags: OsString,
+    ldflags: OsString,
     options: Vec<(Kind, OsString, Option<OsString>)>,
     target: Option<String>,
     make_args: Option<Vec<String>>,
@@ -100,6 +101,7 @@ impl Config {
             path: env::current_dir().unwrap().join(path),
             cflags: OsString::new(),
             cxxflags: OsString::new(),
+            ldflags: OsString::new(),
             options: Vec::new(),
             make_args: None,
             make_targets: None,
@@ -158,6 +160,14 @@ impl Config {
     pub fn cxxflag<P: AsRef<OsStr>>(&mut self, flag: P) -> &mut Config {
         self.cxxflags.push(" ");
         self.cxxflags.push(flag.as_ref());
+        self
+    }
+
+    /// Adds a custom flag to pass down to the linker, supplementing those
+    /// that this library already passes.
+    pub fn ldflag<P: AsRef<OsStr>>(&mut self, flag: P) -> &mut Config {
+        self.ldflags.push(" ");
+        self.ldflags.push(flag.as_ref());
         self
     }
 
@@ -291,6 +301,10 @@ impl Config {
 
         if !self.cxxflags.is_empty() {
             cmd.env("CXXFLAGS", &self.cxxflags);
+        }
+
+        if !self.ldflags.is_empty() {
+            cmd.env("LDFLAGS", &self.ldflags);
         }
 
         for &(ref kind, ref k, ref v) in &self.options {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,14 @@ impl Config {
         // TODO: make it optional?
         cmd.arg("--disable-shared").arg("--enable-static");
 
+        if !self.cflags.is_empty() {
+            cmd.env("CFLAGS", &self.cflags);
+        }
+
+        if !self.cxxflags.is_empty() {
+            cmd.env("CXXFLAGS", &self.cxxflags);
+        }
+
         for &(ref kind, ref k, ref v) in &self.options {
             let mut os = OsString::from("--");
             match *kind {


### PR DESCRIPTION
Note that I started trying to make the `.cflags()` method no longer be a no-op. But I also need `LDFLAGS`, and since the implementations were similar enough, I just added that in as well.

This fixes #8 but does not automatically add `out_dir` to CFLAGS/LDFLAGS. I don't know enough about compilation tools to know if `-I` and `-L` are universally accepted across all toolchains autotools is likely to run against. I also don't know if they should be automatic defaults, or if something like `.add_out_dir_to_search_paths()` should be a builder method. But in any case I'm now unblocked.

I'd like to merge this change as soon as is practical for you. I'm the author of the spatialite-sys crate, and I have a long dependency chain to make this work. I'd like to push a 0.2.0 that vendors all of these dependencies and incorporates autotools, and I'd rather 0.2.0 not depend on a Git dependency on my fork. :)

Thanks!