### PR TITLE
Pass `host` to ./configure via `--host=`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,7 @@ impl Config {
         let executable = PathBuf::from(&self.path).join("configure");
         let mut cmd = Command::new(executable);
 
+        cmd.arg(format!("--host={}", host));
         cmd.arg(format!("--prefix={}", dst.display()));
         if self.enable_shared {
             cmd.arg("--enable-shared");


### PR DESCRIPTION
Without this change, I can't cross-compile to Android (or presumably any system incompatible with the host) because ./configure tries and fails to run test binaries it compiles. This appears to be a no-op when the architectures equal, but gets cross-compilation working when an incompatible `--target` is passed.