### PR TITLE
Expand docs, dump config.log on failure, version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autotools"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 keywords = ["build-dependencies"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ the API tries to be as similar as possible to it.
 ``` toml
 # Cargo.toml
 [build-dependencies]
-autotools = "0.2"
+autotools = "0.3"
 ```
 
 ``` rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,10 @@ impl Config {
 
     /// Adds a custom flag to pass down to the C compiler, supplementing those
     /// that this library already passes.
+    ///
+    /// Default flags for the chosen compiler have lowest priority, then any
+    /// flags from the environment variable `$CFLAGS`, then any flags specified
+    /// with this method.
     pub fn cflag<P: AsRef<OsStr>>(&mut self, flag: P) -> &mut Config {
         self.cflags.push(" ");
         self.cflags.push(flag.as_ref());
@@ -228,6 +232,10 @@ impl Config {
 
     /// Adds a custom flag to pass down to the C++ compiler, supplementing those
     /// that this library already passes.
+    ///
+    /// Default flags for the chosen compiler have lowest priority, then any
+    /// flags from the environment variable `$CXXFLAGS`, then any flags specified
+    /// with this method.
     pub fn cxxflag<P: AsRef<OsStr>>(&mut self, flag: P) -> &mut Config {
         self.cxxflags.push(" ");
         self.cxxflags.push(flag.as_ref());
@@ -236,6 +244,9 @@ impl Config {
 
     /// Adds a custom flag to pass down to the linker, supplementing those
     /// that this library already passes.
+    ///
+    /// Flags from the environment variable `$LDFLAGS` have lowest priority,
+    /// then any flags specified with this method.
     pub fn ldflag<P: AsRef<OsStr>>(&mut self, flag: P) -> &mut Config {
         self.ldflags.push(" ");
         self.ldflags.push(flag.as_ref());
@@ -277,6 +288,15 @@ impl Config {
 
     /// Configure an environment variable for the `configure && make` processes
     /// spawned by this crate in the `build` step.
+    ///
+    /// If you want to set `$CFLAGS`, `$CXXFLAGS`, or `$LDFLAGS`, consider using the
+    /// [cflag](#method.cflag),
+    /// [cxxflag](#method.cxxflag), or
+    /// [ldflag](#method.ldflag)
+    /// methods instead, which will append to any external
+    /// values. Setting those environment variables here will overwrite the
+    /// external values, and will also discard any flags determined by the chosen
+    /// compiler.
     pub fn env<K, V>(&mut self, key: K, value: V) -> &mut Config
         where K: AsRef<OsStr>,
               V: AsRef<OsStr>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,7 @@ impl Config {
             cmd.env(k, v);
         }
 
-        run(cmd.current_dir(&build), "configure");
+        run_config(cmd.current_dir(&build), &build);
 
         // Build up the first make command to build the build system.
         let executable = env::var("MAKE").unwrap_or("make".to_owned());
@@ -532,6 +532,24 @@ impl Config {
 
     fn maybe_clear(&self, _dir: &Path) {
         // TODO: make clean?
+    }
+}
+
+fn run_config(cmd: &mut Command, path: &Path) {
+    println!("running: {:?}", cmd);
+    let status = match cmd.status() {
+        Ok(status) => status,
+        Err(ref e) if e.kind() == ErrorKind::NotFound => {
+            fail(&format!("failed to execute command: {}\nis `configure` not installed?",
+                          e));
+        }
+        Err(e) => fail(&format!("failed to execute command: {}", e)),
+    };
+    if !status.success() {
+        let executable = "cat".to_owned();
+        let mut cmd = Command::new(executable);
+        cmd.current_dir(path);
+        return run(cmd.arg("config.log"), "cat config.log");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,11 @@ impl Config {
     /// values. Setting those environment variables here will overwrite the
     /// external values, and will also discard any flags determined by the chosen
     /// compiler.
+    ///
+    /// `autotools::Config` will automatically pass `$CC` and `$CXX` values to
+    /// the `configure` script based on the chosen compiler. Setting those
+    /// variables here will override, and interferes with other parts of this
+    /// library, so is not recommended.
     pub fn env<K, V>(&mut self, key: K, value: V) -> &mut Config
         where K: AsRef<OsStr>,
               V: AsRef<OsStr>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```toml
 //! [build-dependencies]
-//! autotools = "0.2"
+//! autotools = "0.3"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION
Made an attempt to document the changes I pushed and you merged recently. Also to give some context about the difference between Rust's (and this package's) interpretation of "host/target" and that of Gnu autotools.

When developing my own package which used this one, I found it helpful to see a dump of `config.log` if the `configure` script failed. Proposing that change here too. Am glad to revert it or make it a separate PR if you like.

Finally, bumped the version. Please consider publishing the new version, so that I can publish my own package that relies on these changes.