### PR TITLE
Use emconfigure and emmake wrappers for emscripten targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autotools"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 license = "MIT"
 keywords = ["build-dependencies"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ a compatible `configure` script + `make`.
 It is based on [cmake-rs](https://github.com/alexcrichton/cmake-rs) and
 the API tries to be as similar as possible to it.
 
+For Emscripten targets like "wasm32-unknown-emscripten", `configure` and
+`make` invocations are passed as arguments to `emconfigure` and `emmake`
+respectively as described in the [Emscripten docs](https://emscripten.org/docs/compiling/Building-Projects.html#integrating-with-a-build-system).
+
 ``` toml
 # Cargo.toml
 [build-dependencies]


### PR DESCRIPTION
Thanks for publishing this project! 

I'm using this crate to build a dependency for a project targeting "wasm32-unknown-emscripten" but had to make some modifications. Emscripten provides wrapper scripts for invocations to `./configure` and `make` (see [docs](https://emscripten.org/docs/compiling/Building-Projects.html#integrating-with-a-build-system)) that get called with the regular `make` or `./configure` commands.  

This PR follows a similar approach to [selecting the compiler in cc-rs](https://github.com/alexcrichton/cc-rs/blob/8a1d5c89f02ebc58480a6e4c5b5c2aa2eb6e07c1/src/lib.rs#L2021-L2031) which will choose `emcc` or `em++` for targets containing the substring "emscripten"

I updated the README to note the change and bumped the version in `Cargo.toml`. Also added some local variables to keep the error message helpful - e.g. when the Emscripten SDK isn't installed, the error for the configure step when compiling Emscripten targets is:
```
  failed to execute command: No such file or directory (os error 2)
  is `emconfigure` not installed?
```