### PR TITLE
Introducing fast-build flag to skip running configure if not needed. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "example/xmp-sys/libxmp"]
 	path = examples/xmp-sys/libxmp
 	url = https://github.com/cmatsuoka/libxmp/
+[submodule "examples/libhello-sys"]
+	path = examples/libhello-sys
+	url = https://github.com/ahmed-masud/libhello-sys.git


### PR DESCRIPTION
In complex projects (e.g. libraries under util-linux) linking against libraries can take a long time and if configure is rerun every time when linking against external programs that use them can be very time consuming.  The `fast_build` flag in build.rs allows for skipping the re-generation of config files and lets the Makefile work out if that needs to be done (automake makefiles are really good at that).

The way I implemented the flag allows for complete backwards compatibility. I have also added a submodule libhello-sys that I created from scratch that I think we can use to build a test suite around the autotools-rs ...

P.S.: This change hyper improved on build times of a production project (~5x improvement) 