### PR TITLE
Enforce minimum required version of cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ A build dependency to build native libraries that use configure&make-style build
 readme = "README.md"
 
 [dependencies]
-cc = "1"
+cc = "1.0.3"


### PR DESCRIPTION
Hi, thanks for your work on `autotools-rs`, which has been useful for me for over a year now.

This morning I found a [link](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277) that helped me understand cargo dependency versions. With some suggestions listed therein, I found that my own crates wouldn't compile with the minimum "supported" versions of my dependencies. `autotools-rs` is such a dependency, but fortunately this was an easy fix; the `cc` dependency is sufficient from 1.0.3 onwards.  Pending any questions you may have, it would be great to get this PR merged and a new release made (I personally think 0.2.5 should be fine, but maybe 0.3.0 is more correct?).

I checked that the tests for `autotools-rs` worked when using `cc` versions 1.0.3 to 1.0.72 with:

    for v in {3..72}; do cargo update -p cc --precise 1.0.${v}; cargo +nightly test --all --all-features; done