### PR TITLE
Always set num_jobs in `make_args`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,13 +688,15 @@ impl Config {
             make_args.extend_from_slice(args);
         }
 
-        if let Ok(s) = env::var("NUM_JOBS") {
+        if let Ok(num_jobs_s) = env::var("NUM_JOBS") {
+            // This looks like `make`, let's hope it understands `-jN`.
+            make_args.push(format!("-j{}", num_jobs_s));
             match env::var_os("CARGO_MAKEFLAGS") {
                 // Only do this on non-windows and non-bsd
                 // On Windows, we could be invoking make instead of
                 // mingw32-make which doesn't work with our jobserver
                 // bsdmake also does not work with our job server
-                Some(ref s)
+                Some(ref cargo_make_flags)
                     if !(cfg!(windows)
                         || cfg!(target_os = "openbsd")
                         || cfg!(target_os = "netbsd")
@@ -702,11 +704,9 @@ impl Config {
                         || cfg!(target_os = "bitrig")
                         || cfg!(target_os = "dragonflybsd")) =>
                 {
-                    makeflags = Some(s.clone())
+                    makeflags = Some(cargo_make_flags.clone())
                 }
-
-                // This looks like `make`, let's hope it understands `-jN`.
-                _ => make_args.push(format!("-j{}", s)),
+                _ => (),
             }
         }
 


### PR DESCRIPTION
I've been getting constant problem while building protobuf-src:

```
 running: cd "/Users/nikolai/workspace/sovereign/sovereign-sdk/target/debug/build/protobuf-src-85fb85c5e7ba3b4a/out/install/build" && MAKEFLAGS="-j --jobserver-fds=7,8 --jobserver-auth=7,8" "sh" "-c" "exec \"$0\" \"$@\"" "make" "install"
  Making install in .
  make[2]: Nothing to be done for `install-exec-am'.
   /opt/homebrew/bin/gmkdir -p '/Users/nikolai/workspace/sovereign/sovereign-sdk/target/debug/build/protobuf-src-85fb85c5e7ba3b4a/out/install/lib/pkgconfig'
   /opt/homebrew/bin/ginstall -c -m 644 protobuf.pc protobuf-lite.pc '/Users/nikolai/workspace/sovereign/sovereign-sdk/target/debug/build/protobuf-src-85fb85c5e7ba3b4a/out/install/lib/pkgconfig'
  Making install in src

  --- stderr
  make[1]: *** read jobs pipe: Resource temporarily unavailable.  Stop.
  make[1]: *** Waiting for unfinished jobs....
  make: *** [install-recursive] Error 1
  thread 'main' panicked at /Users/nikolai/.cargo/registry/src/index.crates.io-6f17d22bba15001f/autotools-0.2.6/src/lib.rs:795:5:

  command did not execute successfully, got: exit status: 2
```

And investigation led me to realize that unbound(`-j`) MAKE jobs is the problem. 

I've tested proposed fix locally and it helps. I understand that this might be not ideal solution, but I still want to bring it to a review